### PR TITLE
Replacestructwithclass

### DIFF
--- a/UniversalEntities/UniversalEntities/Abstracts/IAddress.cs
+++ b/UniversalEntities/UniversalEntities/Abstracts/IAddress.cs
@@ -22,7 +22,7 @@ namespace UniversalEntities
 
         string Country { get; set; }
     }
-    public struct Address : IAddress
+    public class Address : IAddress
     {
         public string City { get; set; }
 

--- a/UniversalEntities/UniversalEntities/Abstracts/IBankAccount.cs
+++ b/UniversalEntities/UniversalEntities/Abstracts/IBankAccount.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace UniversalEntities
 {
-    interface IBankAccount
+    public interface IBankAccount
     {
         string BankName { get; set; }
         string AccountNumber { get; set; }
@@ -14,7 +14,7 @@ namespace UniversalEntities
         string MICR { get; set; }
         string Branch { get; set; }
     }
-    struct BankAccount : IBankAccount
+    public struct BankAccount : IBankAccount
     {
         public string AccountNumber
         {

--- a/UniversalEntities/UniversalEntities/Abstracts/IPersonName.cs
+++ b/UniversalEntities/UniversalEntities/Abstracts/IPersonName.cs
@@ -19,7 +19,7 @@ namespace UniversalEntities
         //string Full { get; set; }
     }
 
-    public struct PersonName : IPersonName
+    public class PersonName : IPersonName
     {
 
         public string First { get; set; }


### PR DESCRIPTION
Apparently, structs are not supported for Serialization<=>Deserialization in MongoDb, hence the structs have been replaced with classes.
It is yet to be discovered whether these classes should be abstract or sealed or whatever
